### PR TITLE
Replace Compile with JavaCompile in gradle build file, since Compile …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,12 +9,12 @@ repositories {
 
 dependencies {
     compile files('libs/ijdk-2.0.0.jar')
-    compile files('libs/qualog-2.1.0.jar')
+    compile files('libs/qualog-2.0.0.jar')
     testCompile group: 'junit', name: 'junit', version: '4.+'
 }
 
 allprojects {
-    tasks.withType(Compile).all { Compile compile ->
+    tasks.withType(JavaCompile).all { JavaCompile compile ->
         compile.options.debug = true
         compile.options.compilerArgs = ['-Xlint:all']
     }


### PR DESCRIPTION
…is deprecated

In addition,  there is a reference to version `2.1.0` of `qualog` while its latest published version is `2.0.0`. 
